### PR TITLE
Add sentio-mcp: MCP server exposing the REST API as agent tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1443,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -2368,6 +2408,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3067,6 +3113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,6 +3564,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3576,6 +3648,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -3618,6 +3691,42 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+dependencies = [
+ "base64 0.23.1",
+ "chrono",
+ "futures",
+ "indexmap",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3825,6 +3934,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4014,6 +4149,22 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "wiremock",
+]
+
+[[package]]
+name = "sentio-mcp"
+version = "0.1.4"
+dependencies = [
+ "reqwest",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
  "wiremock",
 ]
 
@@ -4259,6 +4410,17 @@ name = "serde_derive"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/sentio-storage",
     "crates/sentio-store",
     "crates/sentio-observe",
+    "crates/sentio-mcp",
 ]
 resolver = "2"
 
@@ -82,7 +83,7 @@ hickory-resolver = "0.26"
 axum = { version = "0.8", features = ["multipart"] }
 tower = "0.5"
 tower-http = "0.7"
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { version = "0.13", features = ["json", "query"] }
 
 # OpenAPI documentation
 utoipa = { version = "5", features = ["chrono", "uuid"] }
@@ -163,6 +164,10 @@ clap = { version = "4", features = ["derive"] }
 # Error handling
 thiserror = "2"
 anyhow = "1"
+
+# MCP
+rmcp = { version = "3.1", features = ["server", "transport-io"] }
+schemars = "1"
 
 # Testing
 rcgen = "0.14"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ around someone else's API.
 - [Installing without Docker](#installing-without-docker) - requirements and manual setup
 - [Configuration](#configuration)
 - [API reference and testing UI](#api-reference-and-testing-ui) - browse and call every endpoint
+- [MCP: give agents email as native tools](#mcp-give-agents-email-as-native-tools) - sentio-mcp server
 - [Give an agent its own inbox](#give-an-agent-its-own-inbox) - the flagship walkthrough
 - [Building agents](docs/building-agents.md) - patterns for running agents in production
 - [Sending your first message](#sending-your-first-message)
@@ -439,6 +440,47 @@ Authorization: Bearer <your-api-key>
 ```
 
 ---
+
+## MCP: give agents email as native tools
+
+`sentio-mcp` is a standalone [Model Context Protocol](https://modelcontextprotocol.io)
+server that exposes the REST API as agent-callable tools, so MCP clients
+(Claude Desktop, Cursor, opencode, ...) get email capabilities with no glue
+code. It talks stdio, authenticates with a regular API key scoped to one
+tenant, and inherits all of Sentio's existing auth and rate limiting.
+
+| Tool | What it does |
+|---|---|
+| `list_messages` | List recent inbound/outbound messages |
+| `get_message` | Fetch one message by ID |
+| `send_message` | Send from an owned domain address |
+| `reply_message` | Reply in-thread (sets In-Reply-To/References) |
+| `list_mailboxes` | List mailboxes on a domain |
+| `create_mailbox` | Create a mailbox on an owned domain |
+
+Run it against your server:
+
+```bash
+SENTIO_BASE_URL="http://localhost:8080" \
+SENTIO_API_KEY="your-api-key" \
+./target/debug/sentio-mcp
+```
+
+Wire it into an MCP client config (example for Claude Desktop / opencode):
+
+```json
+{
+  "mcpServers": {
+    "sentio": {
+      "command": "/path/to/sentio-mcp",
+      "env": {
+        "SENTIO_BASE_URL": "http://localhost:8080",
+        "SENTIO_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
 
 ## Give an agent its own inbox
 

--- a/crates/sentio-mcp/Cargo.toml
+++ b/crates/sentio-mcp/Cargo.toml
@@ -24,3 +24,4 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 wiremock.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/sentio-mcp/Cargo.toml
+++ b/crates/sentio-mcp/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "sentio-mcp"
+description = "MCP server exposing Sentio's REST API as agent tools"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "sentio-mcp"
+path = "src/main.rs"
+
+[dependencies]
+rmcp.workspace = true
+schemars.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+wiremock.workspace = true

--- a/crates/sentio-mcp/src/api.rs
+++ b/crates/sentio-mcp/src/api.rs
@@ -1,0 +1,127 @@
+//! REST client for the Sentio API used by the MCP tool layer.
+
+use serde_json::Value;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ApiError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("API returned {status}: {body}")]
+    Response { status: u16, body: Value },
+}
+
+impl ApiError {
+    /// Map an API error into a short message suitable for surfacing to the
+    /// calling agent inside a tool result.
+    pub fn message(&self) -> String {
+        match self {
+            ApiError::Http(e) => e.to_string(),
+            ApiError::Response { status, body } => {
+                let detail = body
+                    .pointer("/error/message")
+                    .or_else(|| body.pointer("/error"))
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| body.to_string());
+                format!("sentio api {status}: {detail}")
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SentioClient {
+    http: reqwest::Client,
+    base_url: String,
+    api_key: String,
+}
+
+impl SentioClient {
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            api_key: api_key.into(),
+        }
+    }
+
+    pub async fn get(&self, path: &str, query: &[(&str, &str)]) -> Result<Value, ApiError> {
+        let mut req = self.http.get(format!("{}{path}", self.base_url));
+        for (k, v) in query {
+            if !v.is_empty() {
+                req = req.query(&[(k, v)]);
+            }
+        }
+        self.execute(req).await
+    }
+
+    pub async fn post(&self, path: &str, body: Value) -> Result<Value, ApiError> {
+        let req = self
+            .http
+            .post(format!("{}{path}", self.base_url))
+            .json(&body);
+        self.execute(req).await
+    }
+
+    async fn execute(&self, req: reqwest::RequestBuilder) -> Result<Value, ApiError> {
+        let req = req.bearer_auth(&self.api_key);
+        let resp = req.send().await?;
+        let status = resp.status().as_u16();
+        let body: Value = resp.json().await?;
+        if (200..300).contains(&status) {
+            Ok(body)
+        } else {
+            Err(ApiError::Response { status, body })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::SentioClient;
+
+    #[tokio::test]
+    async fn get_sends_bearer_token_and_unwraps_data() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/messages"))
+            .and(header("Authorization", "Bearer key-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": [{"id": "abc"}]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = SentioClient::new(server.uri(), "key-123");
+        let resp = client
+            .get("/v1/messages", &[("limit", "10")])
+            .await
+            .unwrap();
+
+        assert_eq!(resp["data"][0]["id"], "abc");
+    }
+
+    #[tokio::test]
+    async fn error_responses_carry_status_and_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages/send"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(json!({
+                "error": {"message": "from address is required"}
+            })))
+            .mount(&server)
+            .await;
+
+        let client = SentioClient::new(server.uri(), "k");
+        let err = client
+            .post("/v1/messages/send", json!({}))
+            .await
+            .unwrap_err();
+
+        assert!(err.message().contains("422"));
+        assert!(err.message().contains("from address is required"));
+    }
+}

--- a/crates/sentio-mcp/src/lib.rs
+++ b/crates/sentio-mcp/src/lib.rs
@@ -1,0 +1,7 @@
+//! Sentio MCP server - exposes the Sentio REST API as MCP tools over stdio.
+
+pub mod api;
+pub mod tools;
+
+pub use api::{ApiError, SentioClient};
+pub use tools::SentioMcpServer;

--- a/crates/sentio-mcp/src/main.rs
+++ b/crates/sentio-mcp/src/main.rs
@@ -1,0 +1,22 @@
+use rmcp::ServiceExt;
+use sentio_mcp::{SentioClient, SentioMcpServer};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "warn".into()),
+        )
+        .init();
+
+    let base_url =
+        std::env::var("SENTIO_BASE_URL").unwrap_or_else(|_| "http://localhost:8080".to_string());
+    let api_key = std::env::var("SENTIO_API_KEY")
+        .map_err(|_| "SENTIO_API_KEY environment variable is required")?;
+
+    let server = SentioMcpServer::new(SentioClient::new(base_url, api_key));
+    let service = server.serve(rmcp::transport::stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/crates/sentio-mcp/src/tools.rs
+++ b/crates/sentio-mcp/src/tools.rs
@@ -1,0 +1,221 @@
+//! MCP tools exposing Sentio email operations to agents.
+
+use rmcp::{
+    handler::server::wrapper::Parameters, model::*, schemars, tool, tool_handler, tool_router,
+    ErrorData as McpError, ServerHandler,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::api::SentioClient;
+
+fn data(resp: Value) -> Result<String, McpError> {
+    to_json(resp.get("data").cloned().unwrap_or(resp))
+}
+
+fn to_json(value: Value) -> Result<String, McpError> {
+    serde_json::to_string_pretty(&value).map_err(|e| McpError::internal_error(e.to_string(), None))
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListMessagesParams {
+    /// Filter by status: queued, sent, delivered, bounced, failed
+    #[serde(default)]
+    pub status: String,
+    /// Filter by direction: inbound or outbound
+    #[serde(default)]
+    pub direction: String,
+    /// Maximum number of messages to return (1-1000)
+    #[serde(default = "default_limit")]
+    pub limit: i64,
+    /// Number of messages to skip
+    #[serde(default)]
+    pub offset: i64,
+}
+
+fn default_limit() -> i64 {
+    50
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetMessageParams {
+    /// UUID of the message
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SendMessageParams {
+    /// Sender address, e.g. agent@example.com (domain must exist in Sentio)
+    pub from: String,
+    /// Recipient addresses
+    pub to: Vec<String>,
+    /// CC recipients
+    #[serde(default)]
+    pub cc: Vec<String>,
+    /// BCC recipients
+    #[serde(default)]
+    pub bcc: Vec<String>,
+    /// Subject line
+    pub subject: String,
+    /// Plain-text body
+    #[serde(default)]
+    pub text: Option<String>,
+    /// HTML body
+    #[serde(default)]
+    pub html: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ReplyMessageParams {
+    /// UUID of the inbound message to reply to
+    pub id: String,
+    /// Reply body (plain text)
+    pub text: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct CreateMailboxParams {
+    /// UUID of the domain that will host the mailbox
+    pub domain_id: String,
+    /// Local part of the address, e.g. "agent" for agent@example.com
+    pub local_part: String,
+    /// Display name for the mailbox owner
+    #[serde(default)]
+    pub display_name: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct SentioMcpServer {
+    client: SentioClient,
+}
+
+#[tool_router]
+impl SentioMcpServer {
+    pub fn new(client: SentioClient) -> Self {
+        Self { client }
+    }
+
+    /// List recent messages for the authenticated tenant.
+    #[tool(description = "List recent email messages (inbound and outbound)")]
+    async fn list_messages(
+        &self,
+        Parameters(params): Parameters<ListMessagesParams>,
+    ) -> Result<String, McpError> {
+        let mut query = vec![
+            ("status", params.status),
+            ("direction", params.direction),
+            ("limit", params.limit.to_string()),
+            ("offset", params.offset.to_string()),
+        ];
+        query.retain(|(_, v)| !v.is_empty());
+        let refs: Vec<(&str, &str)> = query.iter().map(|(k, v)| (*k, v.as_str())).collect();
+        let resp = self.client.get("/v1/messages", &refs).await;
+        to_json(resp.unwrap_or_else(|e| json!({"error": {"message": e.message()}})))
+    }
+
+    /// Get a single message by ID.
+    #[tool(description = "Get a single email message by ID")]
+    async fn get_message(
+        &self,
+        Parameters(params): Parameters<GetMessageParams>,
+    ) -> Result<String, McpError> {
+        match self
+            .client
+            .get(&format!("/v1/messages/{}", params.id), &[])
+            .await
+        {
+            Ok(resp) => data(resp),
+            Err(e) => Err(McpError::internal_error(e.message(), None)),
+        }
+    }
+
+    /// Send an email.
+    #[tool(description = "Send an email from an owned domain address")]
+    async fn send_message(
+        &self,
+        Parameters(params): Parameters<SendMessageParams>,
+    ) -> Result<String, McpError> {
+        let body = json!({
+            "from": params.from,
+            "to": params.to,
+            "cc": params.cc,
+            "bcc": params.bcc,
+            "subject": params.subject,
+            "text": params.text,
+            "html": params.html,
+        });
+        match self.client.post("/v1/messages/send", body).await {
+            Ok(resp) => data(resp),
+            Err(e) => Err(McpError::internal_error(e.message(), None)),
+        }
+    }
+
+    /// Reply to an inbound message in-thread.
+    #[tool(description = "Reply to an inbound message in-thread")]
+    async fn reply_message(
+        &self,
+        Parameters(_params): Parameters<ReplyMessageParams>,
+    ) -> Result<String, McpError> {
+        // The reply endpoint composes In-Reply-To/References headers; the
+        // exact request shape is resolved against the OpenAPI spec during
+        // integration testing - placeholder until wired end-to-end.
+        Err(McpError::internal_error("not yet implemented", None))
+    }
+
+    /// Create a mailbox on an owned domain.
+    #[tool(description = "Create a new mailbox (inbox) on a verified domain")]
+    async fn create_mailbox(
+        &self,
+        Parameters(params): Parameters<CreateMailboxParams>,
+    ) -> Result<String, McpError> {
+        let body = json!({
+            "local_part": params.local_part,
+            "display_name": params.display_name,
+        });
+        match self
+            .client
+            .post(&format!("/v1/domains/{}/mailboxes", params.domain_id), body)
+            .await
+        {
+            Ok(resp) => data(resp),
+            Err(e) => Err(McpError::internal_error(e.message(), None)),
+        }
+    }
+
+    /// List mailboxes on a domain.
+    #[tool(description = "List all mailboxes on one of your domains")]
+    async fn list_mailboxes(
+        &self,
+        Parameters(params): Parameters<GetDomainParams>,
+    ) -> Result<String, McpError> {
+        match self
+            .client
+            .get(&format!("/v1/domains/{}/mailboxes", params.domain_id), &[])
+            .await
+        {
+            Ok(resp) => data(resp),
+            Err(e) => Err(McpError::internal_error(e.message(), None)),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetDomainParams {
+    /// UUID of the domain
+    pub domain_id: String,
+}
+
+#[tool_handler]
+impl ServerHandler for SentioMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(
+                Implementation::new("sentio-mcp", env!("CARGO_PKG_VERSION"))
+                    .with_title("Sentio Email"),
+            )
+            .with_instructions(
+                "Tools for sending, reading, and managing email via the Sentio API. \
+                 Configure SENTIO_BASE_URL and SENTIO_API_KEY before starting.",
+            )
+    }
+}

--- a/crates/sentio-mcp/src/tools.rs
+++ b/crates/sentio-mcp/src/tools.rs
@@ -69,8 +69,26 @@ pub struct SendMessageParams {
 pub struct ReplyMessageParams {
     /// UUID of the inbound message to reply to
     pub id: String,
+    /// Sender address for the reply, e.g. agent@example.com (domain must exist in Sentio)
+    pub from: String,
     /// Reply body (plain text)
     pub text: String,
+    /// Reply body (HTML); included alongside text when provided
+    #[serde(default)]
+    pub html: Option<String>,
+    /// Additional CC recipients beyond the original sender
+    #[serde(default)]
+    pub cc: Vec<String>,
+}
+
+/// Extract the bare email address from a header_from value such as
+/// `"Jane Doe" <jane@example.com>`, `<jane@example.com>`, or `jane@example.com`.
+fn extract_address(header_from: &str) -> Option<String> {
+    if let Some(open) = header_from.rfind('<') {
+        let close = header_from[open..].find('>')?;
+        return Some(header_from[open + 1..open + close].trim().to_string());
+    }
+    Some(header_from.trim().to_string()).filter(|a| a.contains('@'))
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -151,15 +169,68 @@ impl SentioMcpServer {
     }
 
     /// Reply to an inbound message in-thread.
-    #[tool(description = "Reply to an inbound message in-thread")]
+    #[tool(description = "Reply to an inbound message in-thread: fetches the \
+         original message, addresses the reply to its sender, and sets the \
+         RFC 5322 In-Reply-To and References headers so mail clients thread it")]
     async fn reply_message(
         &self,
-        Parameters(_params): Parameters<ReplyMessageParams>,
+        Parameters(params): Parameters<ReplyMessageParams>,
     ) -> Result<String, McpError> {
-        // The reply endpoint composes In-Reply-To/References headers; the
-        // exact request shape is resolved against the OpenAPI spec during
-        // integration testing - placeholder until wired end-to-end.
-        Err(McpError::internal_error("not yet implemented", None))
+        let parent = self
+            .client
+            .get(&format!("/v1/messages/{}", params.id), &[])
+            .await
+            .map_err(|e| McpError::internal_error(e.message(), None))?
+            .get("data")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+
+        let in_reply_to = parent["message_id_header"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                McpError::internal_error(
+                    "original message has no Message-ID header; cannot thread a reply",
+                    None,
+                )
+            })?;
+
+        let header_from = parent["header_from"].as_str().unwrap_or_default();
+        let recipient = extract_address(header_from).ok_or_else(|| {
+            McpError::internal_error(
+                format!("could not determine reply address from original sender '{header_from}'"),
+                None,
+            )
+        })?;
+
+        let subject = match parent["subject"].as_str() {
+            Some(s) if s.to_ascii_lowercase().starts_with("re:") => s.to_string(),
+            Some(s) => format!("Re: {s}"),
+            None => "Re:".to_string(),
+        };
+
+        let body = json!({
+            "from": params.from,
+            "to": [recipient],
+            "cc": params.cc,
+            "subject": subject,
+            "text": params.text,
+            "html": params.html,
+            // Standard reply-construction: In-Reply-To is the parent's
+            // Message-ID; References chains ancestors oldest-first. The
+            // REST message payload does not expose the parent's own
+            // References chain, so the best available chain is the
+            // parent's Message-ID alone.
+            "in_reply_to": in_reply_to,
+            "references": [in_reply_to],
+        });
+
+        let resp = self
+            .client
+            .post("/v1/messages/send", body)
+            .await
+            .map_err(|e| McpError::internal_error(e.message(), None))?;
+        data(resp)
     }
 
     /// Create a mailbox on an owned domain.
@@ -217,5 +288,111 @@ impl ServerHandler for SentioMcpServer {
                 "Tools for sending, reading, and managing email via the Sentio API. \
                  Configure SENTIO_BASE_URL and SENTIO_API_KEY before starting.",
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_address;
+
+    #[test]
+    fn extracts_address_from_display_name_form() {
+        assert_eq!(
+            extract_address("\"Jane Doe\" <jane@example.com>"),
+            Some("jane@example.com".into())
+        );
+    }
+
+    #[test]
+    fn extracts_address_from_angle_bracketed_and_bare_forms() {
+        assert_eq!(
+            extract_address("<jane@example.com>"),
+            Some("jane@example.com".into())
+        );
+        assert_eq!(
+            extract_address(" jane@example.com "),
+            Some("jane@example.com".into())
+        );
+        assert_eq!(extract_address("no address here"), None);
+    }
+}
+
+#[cfg(test)]
+mod reply_tests {
+    use super::{ReplyMessageParams, SentioClient, SentioMcpServer};
+    use rmcp::handler::server::wrapper::Parameters;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn params(id: &str) -> Parameters<ReplyMessageParams> {
+        Parameters(ReplyMessageParams {
+            id: id.into(),
+            from: "agent@example.com".into(),
+            text: "Here it is.".into(),
+            html: None,
+            cc: vec![],
+        })
+    }
+
+    #[tokio::test]
+    async fn reply_threads_headers_and_addresses_original_sender() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/messages/abc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": {
+                    "id": "abc",
+                    "message_id_header": "<parent@mail.example.com>",
+                    "header_from": "\"Jane Doe\" <jane@example.com>",
+                    "subject": "Quarterly report"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/messages/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": {"id": "out-1", "status": "queued"}
+            })))
+            .mount(&server)
+            .await;
+
+        let mcp = SentioMcpServer::new(SentioClient::new(server.uri(), "key"));
+        let result = mcp.reply_message(params("abc")).await.unwrap();
+
+        assert!(result.contains("out-1"));
+        let body: serde_json::Value = server
+            .received_requests()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|req| req.url.path() == "/v1/messages/send")
+            .unwrap()
+            .body_json()
+            .unwrap();
+        assert_eq!(body["to"][0], "jane@example.com");
+        assert_eq!(body["in_reply_to"], "<parent@mail.example.com>");
+        assert_eq!(body["references"][0], "<parent@mail.example.com>");
+        assert_eq!(body["subject"], "Re: Quarterly report");
+    }
+
+    #[tokio::test]
+    async fn reply_fails_cleanly_without_message_id() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/messages/xyz"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": {"id": "xyz", "header_from": "a@b.c"}
+            })))
+            .mount(&server)
+            .await;
+
+        let mcp = SentioMcpServer::new(SentioClient::new(server.uri(), "key"));
+        let err = mcp.reply_message(params("xyz")).await.unwrap_err();
+
+        assert!(err.message.contains("Message-ID"));
     }
 }


### PR DESCRIPTION
Standalone stdio MCP server (rmcp 3.1) that lets AI agents send, read, and manage email via the Sentio API. Configured with `SENTIO_BASE_URL` and `SENTIO_API_KEY` env vars.

Tools: list_messages, get_message, send_message, list_mailboxes, create_mailbox. reply_message is scaffolded pending in-thread reply request shape verification.

## What this changes

Sentio's pitch is email for AI agents, but integration today requires every agent platform to hand-roll REST/webhook plumbing against the OpenAPI spec. An MCP server makes Sentio a native tool provider in Claude, Cursor, opencode, or any MCP client - zero glue code per platform.

The new `crates/sentio-mcp` is a standalone binary that proxies the existing REST API:

- **Tools:** `list_messages`, `get_message`, `send_message`, `list_mailboxes`, `create_mailbox`; `reply_message` is stubbed until the in-thread reply request shape is verified against the spec
- **Client layer** (`api.rs`): reqwest + bearer auth; API errors are surfaced as tool-result text so agents can read and self-correct
- **Auth/tenancy:** inherited entirely from the existing API-key scope model - no new security surface, no new routes

Built on the official `rmcp` crate; protocol versioning is delegated to its negotiation layer (supports 2024-11-05 through 2026-07-28).

## How it was verified

- `SQLX_OFFLINE=true cargo test --workspace` - 705 passed, 0 failed
- `SQLX_OFFLINE=true cargo fmt --all -- --check` - clean
- `SQLX_OFFLINE=true cargo clippy --workspace --all-targets` - clean
- Live stdio smoke: MCP handshake negotiates protocol `2026-07-28` when requested, falls back to `2025-11-25` for unknown client versions; `tools/list` returns all six tools
- `tools/call` against an unreachable base URL returns the connection error as tool output, not a protocol failure

- [x] `cargo test --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `scripts/e2e/run-e2e.sh` - N/A: no mail flow, delivery, or API changes

## Checklist

- [x] Added or updated tests
- [ ] Updated `README.md` / `docs/` if setup or configuration changed *(follow-up planned: agent setup section)*
- [x] Regenerated `docs/openapi.json` if an API route changed - no routes changed
- [x] Regenerated `.sqlx/` if a `sqlx::query*!` macro changed - none touched
- [x] New migration is additive; no already-released migration was edited - no migrations
