### PR TITLE
Distinguish auth backend failures from invalid tokens; warn on active bootstrap key

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ curl localhost:8080/health/ready
 
 ### Bootstrap credentials
 
-Migration `007` seeds one admin tenant and one API key:
+Migration `002` seeds one admin tenant and one API key:
 
 | | |
 |---|---|

--- a/crates/sentio-api/src/auth.rs
+++ b/crates/sentio-api/src/auth.rs
@@ -58,13 +58,24 @@ impl FromRequestParts<AppState> for AuthContext {
                 hex::encode(hasher.finalize())
             };
 
-            // Try API key first
+            // Try API key first. A miss is signalled by SentioError::Auth;
+            // any other error is an infrastructure failure and must not be
+            // reported to the caller as a bad token.
             let api_key_repo = PgApiKeyRepository::new(pool.clone());
-            if let Ok(record) = api_key_repo.verify(&key_hash).await {
-                return Ok(AuthContext {
-                    tenant_id: record.tenant_id,
-                    scopes: record.scopes,
-                });
+            match api_key_repo.verify(&key_hash).await {
+                Ok(record) => {
+                    return Ok(AuthContext {
+                        tenant_id: record.tenant_id,
+                        scopes: record.scopes,
+                    });
+                }
+                Err(sentio_core::error::SentioError::Auth(_)) => {}
+                Err(e) => {
+                    tracing::error!("api key lookup failed: {e}");
+                    return Err(ApiError::Internal(
+                        "authentication backend unavailable".into(),
+                    ));
+                }
             }
 
             // Fall back to OAuth bearer token
@@ -82,8 +93,53 @@ impl FromRequestParts<AppState> for AuthContext {
                         scopes: record.scopes,
                     })
                 }
-                Err(_) => Err(ApiError::Auth("invalid or expired token".into())),
+                Err(sentio_core::error::SentioError::Auth(_)) => {
+                    Err(ApiError::Auth("invalid or expired token".into()))
+                }
+                Err(e) => {
+                    tracing::error!("oauth token lookup failed: {e}");
+                    Err(ApiError::Internal(
+                        "authentication backend unavailable".into(),
+                    ))
+                }
             }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Bootstrap credential check
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Warn loudly if the well-known bootstrap admin API key is still active.
+///
+/// `migrations/002_bootstrap.sql` seeds an admin tenant with a publicly-known
+/// key (`sentio_bootstrap_admin_CHANGE_ME`) so a fresh install is usable. The
+/// README instructs operators to rotate it; this check makes a forgotten
+/// rotation impossible to miss at startup.
+pub async fn warn_if_bootstrap_key_active(pool: &sqlx::PgPool) {
+    const BOOTSTRAP_KEY: &str = "sentio_bootstrap_admin_CHANGE_ME";
+
+    let key_hash = {
+        let mut hasher = Sha256::new();
+        hasher.update(BOOTSTRAP_KEY.as_bytes());
+        hex::encode(hasher.finalize())
+    };
+
+    let api_key_repo = PgApiKeyRepository::new(pool.clone());
+    match api_key_repo.verify(&key_hash).await {
+        Ok(record) => {
+            tracing::warn!(
+                key_prefix = %record.key_prefix,
+                "the bootstrap admin API key shipped in migrations/002_bootstrap.sql \
+                 is still active and publicly known - rotate it now via \
+                 POST /v1/tenants/{}/api-keys, then delete the bootstrap key",
+                record.tenant_id
+            );
+        }
+        Err(sentio_core::error::SentioError::Auth(_)) => {}
+        Err(e) => {
+            tracing::debug!(error = %e, "could not check bootstrap key status");
         }
     }
 }

--- a/crates/sentio-api/src/server.rs
+++ b/crates/sentio-api/src/server.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use sentio_core::error::SentioError;
 use tokio::net::TcpListener;
 
+use crate::auth::warn_if_bootstrap_key_active;
 use crate::routes;
 use crate::state::AppState;
 
@@ -17,6 +18,8 @@ pub async fn start(
     let addr = SocketAddr::from_str(listen_addr).map_err(|e| {
         SentioError::Validation(format!("invalid listen_api address '{listen_addr}': {e}"))
     })?;
+
+    warn_if_bootstrap_key_active(&state.pool).await;
 
     let app = routes::router(state);
 


### PR DESCRIPTION
Distinguish auth backend failures from invalid tokens; warn on active bootstrap key

## What this changes

Three small hardening/correctness fixes found during a code review:

1. **Auth no longer masks infrastructure failures as bad tokens.**
   The bearer-token path used `if let Ok(record) = api_key_repo.verify(...)`,
   so any error - including a database outage - was treated as "not an API
   key" and fell through to the OAuth lookup, ultimately answering with
   `401 invalid or expired token`. A Postgres blip would therefore look like
   mass token rejection (and clients would retry aggressively against a
   struggling backend). Now only `SentioError::Auth` (a genuine miss)
   falls through to the next backend; any other error is logged server-side
   and returns `500 authentication backend unavailable`, without leaking
   which backend failed.

2. **Startup warning for the bootstrap admin key.** `migrations/002_bootstrap.sql`
   seeds a publicly-known admin API key so fresh installs are usable, and the
   README tells operators to rotate it. The API now checks at startup whether
   that key is still active and, if so, logs a loud warning including the
   tenant id and rotation instructions. A forgotten rotation is now
   impossible to miss.

3. **README fix:** the bootstrap seed is in migration `002`, not `007`
   (`007` does not exist).

No routes, schemas, or migrations are changed. The auth change alters only
error classification of existing lookups.

## How it was verified

- `SQLX_OFFLINE=true cargo fmt --all -- --check` - clean
- `SQLX_OFFLINE=true cargo clippy --workspace --all-targets` - clean
- `SQLX_OFFLINE=true cargo test --workspace` - 703 passed, 0 failed

Note for reviewers: behavioural testing of the auth path requires a live
Postgres (sentio-api has no DB unit-test harness); this change is covered by
the full test suite plus review. The e2e harness exercises successful auth
but not the backend-failure path.

- [x] `cargo test --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `scripts/e2e/run-e2e.sh` - N/A: no mail flow, delivery, or API changes

## Checklist

- [x] Added or updated tests - no new tests: sentio-api has no DB-backed test harness; flagged above
- [x] Updated `README.md` / `docs/` if setup or configuration changed
- [x] Regenerated `docs/openapi.json` if an API route changed - no routes changed
- [x] Regenerated `.sqlx/` if a `sqlx::query*!` macro changed - none touched
- [x] New migration is additive; no already-released migration was edited - no migrations
