### PR TITLE
Ship sentio-mcp in releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,11 @@ jobs:
         run: |
           # tr: some licence texts carry CRLF, which .gitattributes strips
           # on commit. Without this the diff fails on line endings alone.
-          cargo about generate --fail about.hbs | tr -d '\r' > /tmp/notices.md
+          # --workspace: releases ship sentio-mcp as well as sentio-smtp, and
+          # without it the crawl covers only the root package's dependencies.
+          cargo about generate --fail --workspace about.hbs | tr -d '\r' > /tmp/notices.md
           if ! diff -u THIRD-PARTY-NOTICES.md /tmp/notices.md > /tmp/notices.diff; then
-            echo "::error::THIRD-PARTY-NOTICES.md is stale - regenerate with: cargo about generate --fail about.hbs | tr -d '\r' > THIRD-PARTY-NOTICES.md"
+            echo "::error::THIRD-PARTY-NOTICES.md is stale - regenerate with: cargo about generate --fail --workspace about.hbs | tr -d '\r' > THIRD-PARTY-NOTICES.md"
             echo "--- first 60 lines of the difference ---"
             head -60 /tmp/notices.diff
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,17 +90,23 @@ jobs:
       - name: Build
         env:
           SQLX_OFFLINE: "true"
-        run: cargo build --release --bin sentio-smtp
+        run: cargo build --release -p sentio-smtp -p sentio-mcp --bins
 
       - name: Package
         shell: pwsh
         run: |
           $version = "${{ github.ref_name }}".TrimStart("v")
-          New-Item -ItemType Directory -Path stage | Out-Null
-          Copy-Item target/release/sentio-smtp.exe stage/
-          Copy-Item LICENSE, LICENSE-MIT, LICENSE-APACHE, THIRD-PARTY-NOTICES.md, README.md stage/
+          $docs = @("LICENSE", "LICENSE-MIT", "LICENSE-APACHE", "THIRD-PARTY-NOTICES.md", "README.md")
           New-Item -ItemType Directory -Path dist | Out-Null
-          Compress-Archive -Path stage/* -DestinationPath "dist/sentio-smtp-$version-x86_64-pc-windows-msvc.zip"
+          # Two archives rather than one: an MCP client only needs sentio-mcp,
+          # and a mail server operator only needs sentio-smtp.
+          foreach ($bin in @("sentio-smtp", "sentio-mcp")) {
+            $stage = "stage-$bin"
+            New-Item -ItemType Directory -Path $stage | Out-Null
+            Copy-Item "target/release/$bin.exe" $stage/
+            Copy-Item $docs $stage/
+            Compress-Archive -Path "$stage/*" -DestinationPath "dist/$bin-$version-x86_64-pc-windows-msvc.zip"
+          }
           Get-ChildItem dist
 
       - uses: actions/upload-artifact@v4
@@ -187,12 +193,14 @@ jobs:
           for pair in "linux/amd64:x86_64-unknown-linux-gnu" "linux/arm64:aarch64-unknown-linux-gnu"; do
             platform="${pair%%:*}"; triple="${pair##*:}"
             cid=$(docker create --platform "$platform" "$IMG")
-            docker cp "$cid:/usr/local/bin/sentio-smtp" "sentio-smtp"
+            for bin in sentio-smtp sentio-mcp; do
+              docker cp "$cid:/usr/local/bin/$bin" "$bin"
+              tar -czf "dist/${bin}-${VERSION}-${triple}.tar.gz" \
+                  "$bin" LICENSE LICENSE-MIT LICENSE-APACHE \
+                  THIRD-PARTY-NOTICES.md README.md
+              rm "$bin"
+            done
             docker rm -v "$cid" >/dev/null
-            tar -czf "dist/sentio-smtp-${VERSION}-${triple}.tar.gz" \
-                sentio-smtp LICENSE LICENSE-MIT LICENSE-APACHE \
-                THIRD-PARTY-NOTICES.md README.md
-            rm sentio-smtp
           done
           ls -la dist
 
@@ -241,6 +249,12 @@ jobs:
             echo "| Linux x86_64 | \`sentio-smtp-${VERSION}-x86_64-unknown-linux-gnu.tar.gz\` |"
             echo "| Linux aarch64 | \`sentio-smtp-${VERSION}-aarch64-unknown-linux-gnu.tar.gz\` |"
             echo "| Windows x86_64 | \`sentio-smtp-${VERSION}-x86_64-pc-windows-msvc.zip\` |"
+            echo
+            echo "\`sentio-mcp\`, the MCP server that gives agents email as tools,"
+            echo "ships as its own archive for the same three platforms:"
+            echo "\`sentio-mcp-${VERSION}-<platform>\`. It needs no database of its"
+            echo "own - point it at a running Sentio with SENTIO_BASE_URL and"
+            echo "SENTIO_API_KEY."
             echo
             echo "The Linux builds are dynamically linked and need glibc 2.34 or"
             echo "newer - Debian 12+, Ubuntu 22.04+, RHEL 9+. Binding port 25 as a"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ Two separate things, both enforced in CI:
   dependencies change:
 
 ```bash
-cargo about generate --fail about.hbs | tr -d '\r' > THIRD-PARTY-NOTICES.md
+cargo about generate --fail --workspace about.hbs | tr -d '\r' > THIRD-PARTY-NOTICES.md
 ```
 
 Sentio itself is dual-licensed `MIT OR Apache-2.0`; contributions are accepted

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,10 @@ COPY . .
 # Use the committed .sqlx/ offline cache so the build doesn't need a live DB.
 ENV SQLX_OFFLINE=true
 
-RUN cargo build --release --bin sentio-smtp \
-    && strip target/release/sentio-smtp
+# sentio-mcp rides along so the release job can lift both binaries out of the
+# image instead of running a second set of release builds.
+RUN cargo build --release -p sentio-smtp -p sentio-mcp --bins \
+    && strip target/release/sentio-smtp target/release/sentio-mcp
 
 # ── Runtime ──────────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
@@ -44,6 +46,7 @@ RUN apt-get update \
     && chown -R sentio:sentio /etc/sentio /var/lib/sentio
 
 COPY --from=builder /build/target/release/sentio-smtp /usr/local/bin/sentio-smtp
+COPY --from=builder /build/target/release/sentio-mcp  /usr/local/bin/sentio-mcp
 COPY --from=builder /build/migrations /usr/share/sentio/migrations
 COPY config/oss.toml /etc/sentio/oss.toml
 # Licence obligations travel with the binary, not just the repo.

--- a/README.md
+++ b/README.md
@@ -458,14 +458,27 @@ tenant, and inherits all of Sentio's existing auth and rate limiting.
 | `list_mailboxes` | List mailboxes on a domain |
 | `create_mailbox` | Create a mailbox on an owned domain |
 
-Run it against your server:
+Every release ships `sentio-mcp` as its own archive for Linux x86_64, Linux
+aarch64 and Windows x86_64, so an MCP client host needs no Rust toolchain:
+
+```bash
+VERSION=0.1.4   # or whatever the latest release tag is
+curl -LO "https://github.com/truespar/sentio/releases/download/v${VERSION}/sentio-mcp-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+tar -xzf sentio-mcp-*.tar.gz
+```
+
+Or build it from a checkout:
 
 ```bash
 cargo build --release -p sentio-mcp
+```
 
+Either way, point it at a running Sentio. It keeps no state of its own:
+
+```bash
 SENTIO_BASE_URL="http://localhost:8080" \
 SENTIO_API_KEY="your-api-key" \
-./target/release/sentio-mcp
+./sentio-mcp
 ```
 
 Wire it into an MCP client config (example for Claude Desktop / opencode):

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -8,7 +8,7 @@ Generated from the resolved dependency graph with
 [cargo-about](https://github.com/EmbarkStudios/cargo-about); regenerate with:
 
 ```bash
-cargo about generate --fail about.hbs | tr -d '\r' > THIRD-PARTY-NOTICES.md
+cargo about generate --fail --workspace about.hbs | tr -d '\r' > THIRD-PARTY-NOTICES.md
 ```
 
 Sentio itself is `MIT OR Apache-2.0`; see [LICENSE](LICENSE).
@@ -10325,7 +10325,7 @@ limitations under the License.
 
 ## Apache License 2.0
 
-Used by `allocator-api2 0.2.21`, `async-nats 0.50.0`, `async-trait 0.1.92`, `aws-config 1.11.0`, `aws-credential-types 1.3.0`, `aws-lc-sys 0.44.0`, `aws-runtime 1.9.1`, `aws-sigv4 1.5.1`, `aws-smithy-async 1.3.0`, `aws-smithy-checksums 0.65.0`, `aws-smithy-eventstream 0.61.2`, `aws-smithy-http-client 1.4.0`, `aws-smithy-http 0.64.0`, `aws-smithy-json 0.63.0`, `aws-smithy-observability 0.3.0`, `aws-smithy-query 0.62.0`, `aws-smithy-runtime-api-macros 1.1.0`, `aws-smithy-runtime-api 1.15.0`, `aws-smithy-runtime 1.14.0`, `aws-smithy-schema 0.2.0`, `aws-smithy-types 1.6.2`, `aws-smithy-xml 0.62.0`, `aws-types 1.5.0`, `itoa 1.0.18`, `libc 0.2.189`, `metrics-exporter-prometheus 0.18.3`, `miniz_oxide 0.8.9`, `num-conv 0.2.2`, `pin-project-internal 1.1.13`, `pin-project-lite 0.2.17`, `pin-project 1.1.13`, `portable-atomic 1.15.0`, `proc-macro2 1.0.107`, `quote 1.0.47`, `rand 0.10.2`, `rand 0.8.7`, `rand 0.9.5`, `rand_chacha 0.9.0`, `rand_xoshiro 0.7.0`, `rustversion 1.0.23`, `ryu 1.0.23`, `serde 1.0.229`, `serde_core 1.0.229`, `serde_derive 1.0.229`, `serde_json 1.0.151`, `serde_nanos 0.1.4`, `serde_path_to_error 0.1.20`, `serde_repr 0.1.21`, `serde_urlencoded 0.7.1`, `sqlx-core 0.9.0`, `sqlx-macros-core 0.9.0`, `sqlx-macros 0.9.0`, `sqlx-postgres 0.9.0`, `syn 2.0.119`, `syn 3.0.3`, `sync_wrapper 1.0.2`, `tagptr 0.2.0`, `thiserror-impl 2.0.20`, `thiserror 2.0.20`, `time-core 0.1.9`, `time 0.3.55`, `typed-path 0.12.3`, `unicode-ident 1.0.24`, `utf8parse 0.2.2`, `whoami 2.1.3`
+Used by `allocator-api2 0.2.21`, `async-nats 0.50.0`, `async-trait 0.1.92`, `aws-config 1.11.0`, `aws-credential-types 1.3.0`, `aws-lc-sys 0.44.0`, `aws-runtime 1.9.1`, `aws-sigv4 1.5.1`, `aws-smithy-async 1.3.0`, `aws-smithy-checksums 0.65.0`, `aws-smithy-eventstream 0.61.2`, `aws-smithy-http-client 1.4.0`, `aws-smithy-http 0.64.0`, `aws-smithy-json 0.63.0`, `aws-smithy-observability 0.3.0`, `aws-smithy-query 0.62.0`, `aws-smithy-runtime-api-macros 1.1.0`, `aws-smithy-runtime-api 1.15.0`, `aws-smithy-runtime 1.14.0`, `aws-smithy-schema 0.2.0`, `aws-smithy-types 1.6.2`, `aws-smithy-xml 0.62.0`, `aws-types 1.5.0`, `dyn-clone 1.0.20`, `ident_case 1.0.1`, `itoa 1.0.18`, `libc 0.2.189`, `metrics-exporter-prometheus 0.18.3`, `miniz_oxide 0.8.9`, `num-conv 0.2.2`, `pastey 0.2.3`, `pin-project-internal 1.1.13`, `pin-project-lite 0.2.17`, `pin-project 1.1.13`, `portable-atomic 1.15.0`, `proc-macro2 1.0.107`, `quote 1.0.47`, `rand 0.10.2`, `rand 0.8.7`, `rand 0.9.5`, `rand_chacha 0.9.0`, `rand_xoshiro 0.7.0`, `ref-cast-impl 1.0.27`, `ref-cast 1.0.27`, `rmcp-macros 3.1.4`, `rmcp 3.1.4`, `rustversion 1.0.23`, `ryu 1.0.23`, `serde 1.0.229`, `serde_core 1.0.229`, `serde_derive 1.0.229`, `serde_derive_internals 0.30.0`, `serde_json 1.0.151`, `serde_nanos 0.1.4`, `serde_path_to_error 0.1.20`, `serde_repr 0.1.21`, `serde_urlencoded 0.7.1`, `sqlx-core 0.9.0`, `sqlx-macros-core 0.9.0`, `sqlx-macros 0.9.0`, `sqlx-postgres 0.9.0`, `syn 2.0.119`, `syn 3.0.3`, `sync_wrapper 1.0.2`, `tagptr 0.2.0`, `thiserror-impl 2.0.20`, `thiserror 2.0.20`, `time-core 0.1.9`, `time 0.3.55`, `typed-path 0.12.3`, `unicode-ident 1.0.24`, `utf8parse 0.2.2`, `whoami 2.1.3`
 
 ```
 Apache License
@@ -11732,6 +11732,68 @@ THE SOFTWARE.
 
 ## MIT License
 
+Used by `schemars 1.2.2`
+
+```
+#![allow(clippy::all)]
+use crate::_alloc_prelude::*;
+// Copied from regex_syntax crate to avoid pulling in the whole crate just for a utility function
+// https://github.com/rust-lang/regex/blob/431c4e4867e1eb33eb39b23ed47c9934b2672f8f/regex-syntax/src/lib.rs
+//
+// Copyright (c) 2014 The Rust Project Developers
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the &quot;Software&quot;), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+pub fn escape(text: &amp;str) -&gt; String {
+    let mut quoted &#x3D; String::new();
+    escape_into(text, &amp;mut quoted);
+    quoted
+}
+
+fn escape_into(text: &amp;str, buf: &amp;mut String) {
+    buf.reserve(text.len());
+    for c in text.chars() {
+        if is_meta_character(c) {
+            buf.push(&#x27;\\&#x27;);
+        }
+        buf.push(c);
+    }
+}
+
+fn is_meta_character(c: char) -&gt; bool {
+    match c {
+        &#x27;\\&#x27; | &#x27;.&#x27; | &#x27;+&#x27; | &#x27;*&#x27; | &#x27;?&#x27; | &#x27;(&#x27; | &#x27;)&#x27; | &#x27;|&#x27; | &#x27;[&#x27; | &#x27;]&#x27; | &#x27;{&#x27; | &#x27;}&#x27; | &#x27;^&#x27; | &#x27;$&#x27;
+        | &#x27;#&#x27; | &#x27;&amp;&#x27; | &#x27;-&#x27; | &#x27;~&#x27; &#x3D;&gt; true,
+        _ &#x3D;&gt; false,
+    }
+}
+
+```
+
+## MIT License
+
 Used by `quanta 0.12.6`
 
 ```
@@ -12401,12 +12463,70 @@ SOFTWARE.
 
 ## MIT License
 
+Used by `darling 0.24.1`, `darling_core 0.24.1`, `darling_macro 0.24.1`
+
+```
+MIT License
+
+Copyright (c) 2017 Ted Driggs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+
+## MIT License
+
 Used by `dashmap 6.2.1`
 
 ```
 MIT License
 
 Copyright (c) 2019 Acrimon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+
+## MIT License
+
+Used by `schemars 1.2.2`, `schemars_derive 1.2.2`
+
+```
+MIT License
+
+Copyright (c) 2019 Graham Esau
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal

--- a/about.hbs
+++ b/about.hbs
@@ -8,7 +8,7 @@ Generated from the resolved dependency graph with
 [cargo-about](https://github.com/EmbarkStudios/cargo-about); regenerate with:
 
 ```bash
-cargo about generate --fail about.hbs | tr -d '\r' > THIRD-PARTY-NOTICES.md
+cargo about generate --fail --workspace about.hbs | tr -d '\r' > THIRD-PARTY-NOTICES.md
 ```
 
 Sentio itself is `MIT OR Apache-2.0`; see [LICENSE](LICENSE).

--- a/about.toml
+++ b/about.toml
@@ -1,7 +1,7 @@
 # cargo-about: which licences may appear in a distributed build, and where to
 # find their texts. This is the attribution side; deny.toml is the policy side.
 #
-#   cargo about generate --fail about.hbs > THIRD-PARTY-NOTICES.md
+#   cargo about generate --fail --workspace about.hbs > THIRD-PARTY-NOTICES.md
 #
 # `targets` is deliberately narrow. Without it the crawl includes crates that
 # only build for other platforms - r-efi is a UEFI-only dependency, and pulling


### PR DESCRIPTION
Both binaries in the image, separate archives per binary, notices generated with --workspace.